### PR TITLE
gx: update go-reuseport

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.6.8: QmQCeEJu7KJm2v29cQi1yg7Xa5tXGCzeenvKNyD9bZb5Mo
+1.6.9: QmcYU4bjgs7dACwDWzfeYKgqkgbd5mKk2ZUCepYXhbtRSB

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmV2WTGC9xu6e8WoBa17mDEpdnCRbhSNxP9goqXAAC2reQ",
+      "hash": "QmdQcv14hCd41WEzNA4avJohJR5sdPqVgFtXZtDz6MTCKx",
       "name": "go-tcp-transport",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     {
       "author": "whyrusleeping",
@@ -126,6 +126,6 @@
   "license": "",
   "name": "go-libp2p-conn",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.6.8"
+  "version": "1.6.9"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-tcp-transport/pull/10


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace