### PR TITLE
Ensure Dialer.Dial has the right peer

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -173,8 +173,7 @@ func (d *Dialer) Dial(ctx context.Context, raddr ma.Multiaddr, remote peer.ID) (
 	// if the connection is not to whom we thought it would be...
 	connRemote := connOut.RemotePeer()
 	if connRemote != remote {
-		connOut.Close()
-		_, err := connOut.Read(nil) // should return any potential errors (ex: from secio)
+		err := connOut.Close()
 		errOut = fmt.Errorf("misdial to %s through %s (got %s): %s", remote, raddr, connRemote, err)
 		logdial["error"] = errOut.Error()
 		logdial["dial"] = "failure"

--- a/dial.go
+++ b/dial.go
@@ -170,6 +170,17 @@ func (d *Dialer) Dial(ctx context.Context, raddr ma.Multiaddr, remote peer.ID) (
 		return nil, errOut
 	}
 
+	// if the connection is not to whom we thought it would be...
+	connRemote := connOut.RemotePeer()
+	if connRemote != remote {
+		connOut.Close()
+		_, err := connOut.Read(nil) // should return any potential errors (ex: from secio)
+		errOut = fmt.Errorf("misdial to %s through %s (got %s): %s", remote, raddr, connRemote, err)
+		logdial["error"] = errOut.Error()
+		logdial["dial"] = "failure"
+		return nil, errOut
+	}
+
 	logdial["dial"] = "success"
 	return connOut, nil
 }


### PR DESCRIPTION
This solves https://github.com/libp2p/go-libp2p/137 by ensuring that we have the right peer when the connection is established.