### PR TITLE
Refactor and fix Listen and Dial concurrency logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ using `go-multistream`.
 ## Install
 
 ```sh
-go get -u github.com/libp2p/go-libp2p-conn
+make deps
 ```
 
 ## Usage
@@ -39,9 +39,9 @@ Encryption is forced on when `go-libp2p-interface-conn.EncryptConnections` is tr
 
 ## Protocol overview
 
-The protocol is fairly straightforward: upon opening a connection, `go-multistream` is used to agree on plaintext (`"/plaintext/1.0.0"`) or encrypted (`"/secio/1.0.0"`). Both peers will only be open to use one or the other.
+The protocol is fairly straightforward: upon opening a connection, `go-multistream` is used to agree on plaintext (`"/plaintext/1.0.0"`) or encrypted (`"/secio/1.0.0"`). Plaintext will only be negotiated iff both peers have `go-libp2p-interface-conn.EncryptConnections` set to `false` or haven't constructed their Listeners/Dialers with secret keys.
 
-If plaintext is selected the connection is used as-is for the rest of its lifetime.
+If plaintext is selected, the connection is used as-is for the rest of its lifetime.
 
 If encrypted is selected, `go-libp2p-secio` is used to negotiate a transparent encrypted tunnel. The negotiation happens before the connection is made available to the library consumer.
 
@@ -54,7 +54,8 @@ Small note: If editing the Readme, please conform to the [standard-readme](https
 ### Tests
 
 ```sh
-go test github.com/libp2p/go-libp2p-conn
+make deps
+go test
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,24 +9,53 @@ go-libp2p-conn
 
 > A library providing 'Connection' objects for libp2p.
 
+This package offers wrappers for `go-libp2p-transport` raw types,
+exposing `go-libp2p-interface-conn` types.
+
+It negotiates either plaintext or secio over the raw connection
+using `go-multistream`.
 
 ## Table of Contents
 
 - [Install](#install)
+- [Usage](#usage)
+- [Protocol overview](#protocol-overview)
 - [Contribute](#contribute)
 - [License](#license)
 
 ## Install
 
 ```sh
-make install
+go get -u github.com/libp2p/go-libp2p-conn
 ```
+
+## Usage
+
+On the server side, a `go-libp2p-transport` Listener is wrapped in a `go-libp2p-interface-conn` Listener with `WrapTransportListener`. Such `iconn.Listener` has a peer identity: an ID and a secret key. These are only used when connections are encrypted, and a missing secret key forces plaintext connections.
+
+On the client side, a `Dialer` creates `go-libp2p-interface-conn` connections using a set of `go-libp2p-transport` Dialers. Like with Listener, a Dialer has an ID and private key identity to be used to negotiate encrypted connections. Dial also checks the peer identity if encryption is enabled by specifying a secret key in Dialer.
+
+Encryption is forced on when `go-libp2p-interface-conn.EncryptConnections` is true and the Dialer/Listener has a secret key, and forced off otherwise.
+
+## Protocol overview
+
+The protocol is fairly straightforward: upon opening a connection, `go-multistream` is used to agree on plaintext (`"/plaintext/1.0.0"`) or encrypted (`"/secio/1.0.0"`). Both peers will only be open to use one or the other.
+
+If plaintext is selected the connection is used as-is for the rest of its lifetime.
+
+If encrypted is selected, `go-libp2p-secio` is used to negotiate a transparent encrypted tunnel. The negotiation happens before the connection is made available to the library consumer.
 
 ## Contribute
 
 PRs are welcome!
 
 Small note: If editing the Readme, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+### Tests
+
+```sh
+go test github.com/libp2p/go-libp2p-conn
+```
 
 ## License
 

--- a/conn.go
+++ b/conn.go
@@ -18,8 +18,8 @@ import (
 
 var log = logging.Logger("conn")
 
-// ReleaseBuffer puts the given byte array back into the buffer pool,
-// first verifying that it is the correct size
+// ReleaseBuffer puts the given byte array back into the appropriate
+// global buffer pool based on its capacity.
 func ReleaseBuffer(b []byte) {
 	log.Debugf("Releasing buffer! (cap,size = %d, %d)", cap(b), len(b))
 	mpool.ByteSlicePool.Put(uint32(cap(b)), b)

--- a/dial.go
+++ b/dial.go
@@ -24,8 +24,6 @@ import (
 // protocol selection as well the handshake, if applicable.
 var DialTimeout = 60 * time.Second
 
-type WrapFunc func(transport.Conn) transport.Conn
-
 // Dialer is an object with a peer identity that can open connections.
 //
 // NewDialer must be used to instantiate new Dialer objects.
@@ -50,7 +48,7 @@ type Dialer struct {
 	Protector ipnet.Protector
 
 	// Wrapper to wrap the raw connection. Can be nil.
-	Wrapper WrapFunc
+	Wrapper ConnWrapper
 
 	fallback transport.Dialer
 }
@@ -59,7 +57,7 @@ type Dialer struct {
 //
 // Before any calls to Dial are made, underlying dialers must be added
 // with AddDialer, and Protector (if any) must be set.
-func NewDialer(p peer.ID, pk ci.PrivKey, wrap WrapFunc) *Dialer {
+func NewDialer(p peer.ID, pk ci.PrivKey, wrap ConnWrapper) *Dialer {
 	return &Dialer{
 		LocalPeer:  p,
 		PrivateKey: pk,

--- a/dial.go
+++ b/dial.go
@@ -72,7 +72,6 @@ func (d *Dialer) String() string {
 }
 
 // Dial connects to a peer over a particular address.
-// raddr must be part of the remote peer Addresses().
 // The remote peer ID is only verified if secure connections are in use.
 // It returns once the connection is established, the protocol negotiated,
 // and the handshake complete (if applicable).

--- a/listen_test.go
+++ b/listen_test.go
@@ -1,0 +1,40 @@
+package conn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tu "github.com/libp2p/go-testutil"
+	grc "github.com/whyrusleeping/gorocheck"
+)
+
+func TestAcceptLeak(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p1 := tu.RandPeerNetParamsOrFatal(t)
+
+	l1, err := Listen(ctx, p1.Addr, p1.ID, p1.PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p1.Addr = l1.Multiaddr() // Addr has been determined by kernel.
+
+	for i := 0; i < connAcceptBuffer+1; i++ {
+		// Dial a full valid connection, but never Accept it, and cancel instead
+		p := tu.RandPeerNetParamsOrFatal(t)
+		d := NewDialer(p.ID, p.PrivKey, nil)
+		if _, err := d.Dial(ctx, l1.Multiaddr(), p1.ID); err != nil {
+			t.Fatal("dial failed: ", err)
+		}
+	}
+
+	cancel()
+	time.Sleep(time.Millisecond * 100)
+
+	err = grc.CheckForLeaks(goroFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Listen

If a connection fully establishes, passing the timeout select in
handleIncoming, but then is never taken out of a full incoming queue,
the goroutine is leaked. handleIncoming will in turn leak waiting for
wg.Done. Canceling the context, closing the listener, or closing the
goprocess don't affect these goroutines. connAcceptBuffer makes this
problem a little less evident, but doesn't fix it.

Also, document the listener background behaviour.

## Dial

If a context cancellation hit after a successful dial but before the send on the done channel, a connection would be leaked. Since almost all operations already supported context, it was cleaner to streamline the operation.

Consider adding context support natively to multiaddr.