### PR TITLE
lock when firing close event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ cache:
 
 notifications:
   email: false
+
+env: GOTFLAGS="-race"

--- a/conn_test.go
+++ b/conn_test.go
@@ -60,7 +60,9 @@ func TestClose(t *testing.T) {
 	testOneSendRecv(t, c1, c2)
 	testOneSendRecv(t, c2, c1)
 
+	go c1.Close()
 	c1.Close()
+
 	testNotOneSendRecv(t, c1, c2)
 
 	c2.Close()


### PR DESCRIPTION
This is technically a race. I have a feeling this used to be protected by a msgio lock around close (which I've now removed to avoid a potential deadlock).