### PR TITLE
increase the timeout for the TestCOnnectionTimeouts test

### DIFF
--- a/dial_test.go
+++ b/dial_test.go
@@ -548,8 +548,8 @@ func TestConnectionTimeouts(t *testing.T) {
 		AcceptTimeout = oldD
 	}(DialTimeout, AcceptTimeout)
 
-	DialTimeout = time.Second * 1
-	AcceptTimeout = time.Second * 1
+	DialTimeout = time.Second * 4
+	AcceptTimeout = time.Second * 4
 
 	p1 := tu.RandPeerNetParamsOrFatal(t)
 


### PR DESCRIPTION
Needed to pass with -race enabled.

fixes #30